### PR TITLE
Add Data field to the qt.conf file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,7 +219,8 @@ bool createQtConf(appdir::AppDir &appDir) {
         << "Prefix = ../" << std::endl
         << "Plugins = plugins" << std::endl
         << "Imports = qml" << std::endl
-        << "Qml2Imports = qml" << std::endl;
+        << "Qml2Imports = qml" << std::endl
+        << "Data = data" << std::endl;
 
     return true;
 }


### PR DESCRIPTION
The data field is required to properly locate QtWebEngine resources.