### PR TITLE
Copy application translation files (.qm) into the usr/translations dir.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(linuxdeploy EXCLUDE_FROM_ALL)
-add_subdirectory(googletest EXCLUDE_FROM_ALL)
+if(NOT TARGET gtest)
+    add_subdirectory(googletest EXCLUDE_FROM_ALL)
+endif()
 
 # required to properly build nlohmann/json v. 2.0.0 on trusty
 set(CMAKE_CXX_STANDARD 11)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 namespace bf = boost::filesystem;
 
 using namespace linuxdeploy::core;
+using namespace linuxdeploy::util::misc;
 using namespace linuxdeploy::core::log;
 
 
@@ -259,6 +260,17 @@ deployTranslations(appdir::AppDir &appDir, const bf::path &qtTranslationsPath, c
 
         if (checkName(fileName))
             appDir.deployFile(*i, appDir.path() / "usr/translations/");
+    }
+
+    const auto& appDirTranslationsPath = appDir.path() / "usr/translations";
+    for (auto& i: bf::recursive_directory_iterator(appDir.path())) {
+        if (!bf::is_regular_file(i) || path_contains_file(appDirTranslationsPath, i))
+            continue;
+
+        const auto fileName = i.path().filename();
+
+        if (strEndsWith(fileName.string(), ".qm"))
+            appDir.deployFile(i, appDir.path() / "usr/translations/");
     }
 
     return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -270,7 +270,7 @@ deployTranslations(appdir::AppDir &appDir, const bf::path &qtTranslationsPath, c
         const auto fileName = i.path().filename();
 
         if (strEndsWith(fileName.string(), ".qm"))
-            appDir.deployFile(i, appDir.path() / "usr/translations/");
+            appDir.createRelativeSymlink(i, appDir.path() / "usr/translations" / fileName);
     }
 
     return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -264,7 +264,7 @@ deployTranslations(appdir::AppDir &appDir, const bf::path &qtTranslationsPath, c
 
     const auto& appDirTranslationsPath = appDir.path() / "usr/translations";
     for (auto& i: bf::recursive_directory_iterator(appDir.path())) {
-        if (!bf::is_regular_file(i) || path_contains_file(appDirTranslationsPath, i))
+        if (!bf::is_regular_file(i) || pathContainsFile(appDirTranslationsPath, i))
             continue;
 
         const auto fileName = i.path().filename();

--- a/src/util.h
+++ b/src/util.h
@@ -142,7 +142,7 @@ static boost::filesystem::path findQmake() {
     return qmakePath;
 }
 
-static bool path_contains_file(boost::filesystem::path dir, boost::filesystem::path file) {
+static bool pathContainsFile(boost::filesystem::path dir, boost::filesystem::path file) {
     // If dir ends with "/" and isn't the root directory, then the final
     // component returned by iterators will include "." and will interfere
     // with the std::equal check below, so we strip it before proceeding.

--- a/src/util.h
+++ b/src/util.h
@@ -141,3 +141,26 @@ static boost::filesystem::path findQmake() {
 
     return qmakePath;
 }
+
+static bool path_contains_file(boost::filesystem::path dir, boost::filesystem::path file) {
+    // If dir ends with "/" and isn't the root directory, then the final
+    // component returned by iterators will include "." and will interfere
+    // with the std::equal check below, so we strip it before proceeding.
+    if (dir.filename() == ".")
+        dir.remove_filename();
+    // We're also not interested in the file's name.
+    assert(file.has_filename());
+    file.remove_filename();
+
+    // If dir has more components than file, then file can't possibly
+    // reside in dir.
+    auto dir_len = std::distance(dir.begin(), dir.end());
+    auto file_len = std::distance(file.begin(), file.end());
+    if (dir_len > file_len)
+        return false;
+
+    // This stops checking when it reaches dir.end(), so it's OK if file
+    // has more directory components afterward. They won't be checked.
+    return std::equal(dir.begin(), dir.end(), file.begin());
+};
+


### PR DESCRIPTION
Search for `.qm` files outside the `usr/translations` dir and copy them into it. 
Provides a solution for #16 depends on https://github.com/linuxdeploy/linuxdeploy/pull/40