### PR TITLE
Undo wayland plugging support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
             - qt510-meta-minimal
             - qt510declarative
             - qt510webengine
-            - qt510wayland
             - mesa-common-dev
     - env: ARCH=i386
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 sudo: required
-# required for Qt 5 wayland packages
-dist: xenial
+dist: trusty
 
 matrix:
   include:
@@ -10,7 +9,7 @@ matrix:
         apt:
           update: true
           sources:
-            - sourceline: 'ppa:beineri/opt-qt-5.12.0-xenial'
+            - sourceline: 'ppa:beineri/opt-qt-5.10.1-trusty'
           packages:
             - libmagic-dev
             - libjpeg-dev
@@ -20,10 +19,10 @@ matrix:
             - gcc
             - g++
             # Packages below are only required by the test srcipt
-            - qt512-meta-minimal
-            - qt512declarative
-            - qt512webengine
-            - qt512wayland
+            - qt510-meta-minimal
+            - qt510declarative
+            - qt510webengine
+            - qt510wayland
             - mesa-common-dev
     - env: ARCH=i386
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
             - qt512webengine
             - qt512wayland
             - mesa-common-dev
-            - libgl1
     - env: ARCH=i386
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
             - g++
             # Packages below are only required by the test srcipt
             - qt512-meta-minimal
-            - qt512-base
             - qt512declarative
             - qt512webengine
             - qt512wayland

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
 script:
   - bash -xe travis/build.sh
   # TODO: allow for cross-compiling the test projects and install i386 packages for build dependencies, then remove $ARCH check
-  #- if [ "$ARCH" == "x86_64" ]; then bash -xe travis/test.sh linuxdeploy-plugin-qt-"$ARCH".AppImage; fi
+  - if [ "$ARCH" == "x86_64" ]; then bash -xe travis/test.sh linuxdeploy-plugin-qt-"$ARCH".AppImage; fi
 
 after_success:
   - ls -lh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
             - g++
             # Packages below are only required by the test srcipt
             - qt512-meta-minimal
-            - qt512base
+            - qt512-base
             - qt512declarative
             - qt512webengine
             - qt512wayland

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,10 +49,8 @@ bool strEndsWith(const std::string &str, const std::string &suffix) {
 bool deployPlatformPlugins(appdir::AppDir &appDir, const bf::path &qtPluginsPath) {
     ldLog() << "Deploying platform plugins" << std::endl;
 
-    for (const std::string& libName : {"libqxcb", "libqwayland-egl", "libqwayland-generic"}) {
-        if (!appDir.deployLibrary(qtPluginsPath / "platforms" / (libName + ".so"), appDir.path() / "usr/plugins/platforms/"))
-            return false;
-    }
+    if (!appDir.deployLibrary(qtPluginsPath / "platforms/libqxcb.so", appDir.path() / "usr/plugins/platforms/"))
+        return false;
 
     for (bf::directory_iterator i(qtPluginsPath / "platforminputcontexts"); i != bf::directory_iterator(); ++i) {
         if (!appDir.deployLibrary(*i, appDir.path() / "usr/plugins/platforminputcontexts/"))
@@ -97,19 +95,6 @@ bool deployXcbglIntegrationPlugins(appdir::AppDir& appDir, const bf::path& qtPlu
     ldLog() << "Deploying xcb-gl integrations" << std::endl;
 
     return deployIntegrationPlugins(appDir, qtPluginsPath, {"xcbglintegrations"});
-}
-
-bool deployWaylandIntegrationPlugins(appdir::AppDir& appDir, const bf::path& qtPluginsPath) {
-    ldLog() << "Deploying wayland integrations" << std::endl;
-
-    const std::initializer_list<bf::path> pluginDirs = {
-        "wayland-graphics-integration-client",
-        "wayland-graphics-integration-server",
-        "wayland-decoration-client",
-        "wayland-shell-integration",
-    };
-
-    return deployIntegrationPlugins(appDir, qtPluginsPath, pluginDirs);
 }
 
 bool deploySvgPlugins(appdir::AppDir &appDir, const bf::path &qtPluginsPath) {
@@ -508,9 +493,6 @@ int main(const int argc, const char *const *const argv) {
         if (module.name == "opengl" || module.name == "gui" || module.name == "xcbqpa") {
             if (!deployXcbglIntegrationPlugins(appDir, qtPluginsPath))
                 return 1;
-
-            if (!deployWaylandIntegrationPlugins(appDir, qtPluginsPath))
-                ldLog() << LD_WARNING << "Failed to deploy wayland integration plugins; this will become an error in the future" << std::endl;
         }
 
         if (module.name == "network") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,7 @@ bool strEndsWith(const std::string &str, const std::string &suffix) {
 bool deployPlatformPlugins(appdir::AppDir &appDir, const bf::path &qtPluginsPath) {
     ldLog() << "Deploying platform plugins" << std::endl;
 
-    for (const std::string& libName : {"libqxcb", "libqwayland-generic"}) {
+    for (const std::string& libName : {"libqxcb", "libqwayland-egl", "libqwayland-generic"}) {
         if (!appDir.deployLibrary(qtPluginsPath / "platforms" / (libName + ".so"), appDir.path() / "usr/plugins/platforms/"))
             return false;
     }

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -40,10 +40,7 @@ pushd "$BUILD_DIR"
 
 git clone --depth=1 https://github.com/linuxdeploy/linuxdeploy-plugin-qt-examples.git
 
-set +e
 source /opt/qt*/bin/qt*-env.sh
-set -e
-
 mkdir -p "$HOME"/.config/qtchooser
 echo "${QTDIR}/bin" > "$HOME"/.config/qtchooser/qt5.10.conf
 echo "${QTDIR}/lib" >> "$HOME"/.config/qtchooser/qt5.10.conf

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -40,7 +40,7 @@ pushd "$BUILD_DIR"
 
 git clone --depth=1 https://github.com/linuxdeploy/linuxdeploy-plugin-qt-examples.git
 
-source /opt/qt*/bin/qt*-env.sh
+source /opt/qt510/bin/qt510-env.sh || echo ""   # hack required, otherwise the script will end whit 1
 mkdir -p "$HOME"/.config/qtchooser
 echo "${QTDIR}/bin" > "$HOME"/.config/qtchooser/qt5.10.conf
 echo "${QTDIR}/lib" >> "$HOME"/.config/qtchooser/qt5.10.conf


### PR DESCRIPTION
The Wayland support required that we binaries were built using ubuntu xenial which makes the plug-in unusable in older distributions also it has other side effects (see #22) that can be better described by @TheAssassin.

This will revert changes related to the Wayland plugin support.