### PR TITLE
Make QGtk 2 Theme and Style deployment optional

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,8 +89,17 @@ bool deployPlatformPlugins(appdir::AppDir &appDir, const bf::path &qtPluginsPath
         // either loading succeeds, then the system Gtk shall be used anyway, otherwise loading fails and Qt will fall
         // back to the default UI theme
         // we don't care whether this works (it's an experimental feature), therefore we ignore the return values
-        appDir.deployFile(platformThemesPath / "libqgtk2.so", platformThemesDestination);
-        appDir.deployFile(stylesPath / "libqgtk2style.so", stylesDestination);
+        bf::path qgtkPlatformThemePath = platformThemesPath / "libqgtk2.so";
+        if (bf::exists(qgtkPlatformThemePath))
+            appDir.deployFile(qgtkPlatformThemePath, platformThemesDestination);
+        else
+            ldLog() << LD_ERROR << "Missing Gtk 2 platform theme file: " << qgtkPlatformThemePath << std::endl;
+
+        bf::path qgtkStylePath = stylesPath / "libqgtk2style.so";
+        if (bf::exists(qgtkStylePath))
+            appDir.deployFile(qgtkStylePath, stylesDestination);
+        else
+            ldLog() << LD_ERROR << "Missing Gtk 2 platform style file: " << qgtkStylePath << std::endl;
     }
 
     return true;


### PR DESCRIPTION
This fixes the failed builds when QGtk 2 Theme and/or Style are not installed or found.

But beware, the app developer must take care of ensuring that the QGtk 2 Theme and/or Style is built and properly installed on the build environment.

@TheAssassin builds were failing because once a file is set for deployment they must exists or the build fails.