### PR TITLE
Fix check_command function

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -22,15 +22,16 @@ typedef struct {
 
 static procOutput check_command(const std::vector<std::string> &args) {
     auto command = subprocess::util::join(args);
-    subprocess::Popen proc(command, subprocess::bufsize{-1}, subprocess::output(subprocess::PIPE), subprocess::error(subprocess::PIPE));
+    subprocess::Popen proc(command, subprocess::bufsize{-1 /* stands for dynamically allocated buffer */},
+                            subprocess::output(subprocess::PIPE), subprocess::error(subprocess::PIPE));
     auto outputs = proc.communicate();
 
     const auto &outBuf = outputs.first.buf;
-    auto outBufEnd = std::find(outBuf.begin(),outBuf.end(), '\0');
+    auto outBufEnd = std::find(outBuf.begin(), outBuf.end(), '\0');
     std::string out(outBuf.begin(), outBufEnd);
 
     const auto &errBuf = outputs.second.buf;
-    auto errBufEnd = std::find(errBuf.begin(),errBuf.end(), '\0');
+    auto errBufEnd = std::find(errBuf.begin(), errBuf.end(), '\0');
     std::string err(errBuf.begin(),  errBufEnd);
 
     int returnCode = proc.retcode();


### PR DESCRIPTION
According to: https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait

>> `Popen::wait` will deadlock when using stdout=PIPE and/or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data. Use communicate() to avoid that.

Despite this documentation is not for cpp-subprocess, the later is inspired by the original Python module therefore similar errors can be expected.

This PR remove that ~possible and NOT proven~ possibility. Also makes the code more simple.

____
Update

I was blaming a bug on cpp-subprocess for being the cause of #37 but it happens that `Popen::wait` does hangs when used with pipes as the warning above states. So this also contributes to fixing #37
