### PR TITLE
Make it possible to opt out of building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,14 @@
 cmake_minimum_required(VERSION 3.6)
 project(linuxdeploy-plugin-qt)
 
+include(CTest)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(lib)
 add_subdirectory(src)
-add_subdirectory(tests)
+
+if (BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory(linuxdeploy EXCLUDE_FROM_ALL)
-if(NOT TARGET gtest)
+if(NOT TARGET gtest AND BUILD_TESTING)
     add_subdirectory(googletest EXCLUDE_FROM_ALL)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-enable_testing()
-
 add_executable(linuxdeploy-plugin-qt-tests test_main.cpp test_deploy_qml.cpp ../src/qml.cpp)
 target_link_libraries(linuxdeploy-plugin-qt-tests linuxdeploy_core args json gtest)
 target_compile_definitions(linuxdeploy-plugin-qt-tests PRIVATE TESTS_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")


### PR DESCRIPTION
Right now you cannot build without building tests, this PR makes it possible to opt out by setting `cmake -DBUILD_TESTING=OFF path/to/repo`, which is I think the standard way cmake people do it (but i'm not an expert).