### PR TITLE
Return multiple deployers per module

### DIFF
--- a/src/deployers/PluginsDeployerFactory.cpp
+++ b/src/deployers/PluginsDeployerFactory.cpp
@@ -29,51 +29,51 @@ PluginsDeployerFactory::PluginsDeployerFactory(AppDir& appDir,
                                                                       qtTranslationsPath(std::move(qtTranslationsPath)),
                                                                       qtDataPath(std::move(qtDataPath)) {}
 
-std::shared_ptr<PluginsDeployer> PluginsDeployerFactory::getInstance(const std::string& moduleName) {
+std::vector<std::shared_ptr<PluginsDeployer>> PluginsDeployerFactory::getDeployers(const std::string& moduleName) {
     if (moduleName == "gui") {
-        return getInstance<PlatformPluginsDeployer>(moduleName);
+        return {getInstance<PlatformPluginsDeployer>(moduleName), getInstance<XcbglIntegrationPluginsDeployer>(moduleName)};
     }
 
-    if (moduleName == "opengl" || moduleName == "gui" || moduleName == "xcbqpa") {
-        return getInstance<XcbglIntegrationPluginsDeployer>(moduleName);
+    if (moduleName == "opengl" || moduleName == "xcbqpa") {
+        return {getInstance<XcbglIntegrationPluginsDeployer>(moduleName)};
     }
 
     if (moduleName == "network") {
-        return getInstance<BearerPluginsDeployer>(moduleName);
+        return {getInstance<BearerPluginsDeployer>(moduleName)};
     }
 
     if (moduleName == "svg") {
-        return getInstance<SvgPluginsDeployer>(moduleName);
+        return {getInstance<SvgPluginsDeployer>(moduleName)};
     }
 
     if (moduleName == "sql") {
-        return getInstance<SqlPluginsDeployer>(moduleName);
+        return {getInstance<SqlPluginsDeployer>(moduleName)};
     }
 
     if (moduleName == "positioning") {
-        return getInstance<PositioningPluginsDeployer>(moduleName);
+        return {getInstance<PositioningPluginsDeployer>(moduleName)};
     }
 
     if (moduleName == "multimedia") {
-        return getInstance<MultimediaPluginsDeployer>(moduleName);
+        return {getInstance<MultimediaPluginsDeployer>(moduleName)};
     }
 
     if (moduleName == "webenginecore") {
-        return getInstance<WebEnginePluginsDeployer>(moduleName);
+        return {getInstance<WebEnginePluginsDeployer>(moduleName)};
     }
 
     if (moduleName == "qml") {
-        return getInstance<QmlPluginsDeployer>(moduleName);
+        return {getInstance<QmlPluginsDeployer>(moduleName)};
     }
 
     if (moduleName == "3dquickrender") {
-        return getInstance<Qt3DPluginsDeployer>(moduleName);
+        return {getInstance<Qt3DPluginsDeployer>(moduleName)};
     }
 
     if (moduleName == "gamepad") {
-        return getInstance<GamepadPluginsDeployer>(moduleName);
+        return {getInstance<GamepadPluginsDeployer>(moduleName)};
     }
 
     // fallback
-    return getInstance<BasicPluginsDeployer>(moduleName);
+    return {getInstance<BasicPluginsDeployer>(moduleName)};
 }

--- a/src/deployers/PluginsDeployerFactory.h
+++ b/src/deployers/PluginsDeployerFactory.h
@@ -47,7 +47,7 @@ namespace linuxdeploy {
                                                 boost::filesystem::path qtTranslationsPath,
                                                 boost::filesystem::path qtDataPath);
 
-                std::shared_ptr<PluginsDeployer> getInstance(const std::string& moduleName);
+                std::vector<std::shared_ptr<PluginsDeployer>> getDeployers(const std::string& moduleName);
             };
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -229,11 +229,11 @@ int main(const int argc, const char *const *const argv) {
     for (const auto& module : qtModulesToDeploy) {
         ldLog() << std::endl << "-- Deploying module:" << module.name << "--" << std::endl;
 
-        auto deployer = deployerFactory.getInstance(module.name);
+        auto deployers = deployerFactory.getDeployers(module.name);
 
-        if (!deployer->deploy()) {
-            return 1;
-        }
+        for (const auto& deployer : deployers)
+            if (!deployer->deploy())
+                return 1;
     }
 
     ldLog() << std::endl << "-- Deploying translations --" << std::endl;


### PR DESCRIPTION
Fixes the issue where only `PlatformPluginsDeployer` not `XcbglIntegrationPluginsDeployer` is deployed whenever `gui` is the only module found (#51).

