### PR TITLE
Relative Path for QML files

### DIFF
--- a/src/qml.cpp
+++ b/src/qml.cpp
@@ -173,7 +173,8 @@ void deployQml(appdir::AppDir &appDir, const boost::filesystem::path &installQml
                     const auto &entry = *i;
 
                     if (!bf::is_directory(entry)) {
-                        auto relativeFilePath = qmlImport.relativePath / bf::relative(entry.path(), qmlImport.path);
+                        // lexically relative doesn't resolve symlinks, so the paths stay correct
+                        auto relativeFilePath = qmlImport.relativePath / entry.path().lexically_relative(qmlImport.path);
                         try {
                             elf::ElfFile file(entry.path());
                             appDir.deployLibrary(entry.path(), targetQmlModulesPath / relativeFilePath);


### PR DESCRIPTION
Calculate the relative path to the imported QML file without resolving
symlinks. The path should be resolved lexically. This solves an issue
where a development QML plugin symlinks its files back to the
source.