### PR TITLE
fix EXTRA_QT_PLUGINS path seperator, Issue #83

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,7 +185,7 @@ int main(const int argc, const char *const *const argv) {
     std::vector<std::string> extraPluginsFromEnv;
     const auto* const extraPluginsFromEnvData = getenv("EXTRA_QT_PLUGINS");
     if (extraPluginsFromEnvData != nullptr)
-        extraPluginsFromEnv = linuxdeploy::util::split(std::string(extraPluginsFromEnvData), ';');
+        extraPluginsFromEnv = linuxdeploy::util::split(std::string(extraPluginsFromEnvData), ':');
 
     for (const auto& pluginsList : {static_cast<std::vector<std::string>>(extraPlugins.Get()), extraPluginsFromEnv}) {
         std::copy_if(qtModules.begin(), qtModules.end(), std::back_inserter(extraQtModules),


### PR DESCRIPTION
fix EXTRA_QT_PLUGINS path seperator, make it consistent with QML_SOURCES_PATHS, QML_MODULES_PATHS, and Linux path separator. Fix Issue #83