### PR TITLE
Add libexecs to path

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,9 +228,9 @@ int main(const int argc, const char *const *const argv) {
             << std::endl;
 
     std::ostringstream newPath;
-    newPath << qtBinsPath.string() << ":" << getenv("PATH");
+    newPath << qtBinsPath.string() << ":" << qtLibexecsPath.string() << ":" << getenv("PATH");
     setenv("PATH", newPath.str().c_str(), true);
-    ldLog() << "Prepending QT_INSTALL_BINS path to $PATH, new $PATH:" << newPath.str() << std::endl;
+    ldLog() << "Prepending QT_INSTALL_BINS and QT_INSTALL_LIBEXECS paths to $PATH, new $PATH:" << newPath.str() << std::endl;
 
 
     auto qtModulesToDeploy = foundQtModules;

--- a/src/util.h
+++ b/src/util.h
@@ -2,6 +2,7 @@
 
 // system includes
 #include <iostream>
+#include <map>
 #include <set>
 #include <sstream>
 #include <tuple>


### PR DESCRIPTION
Qt 6.2 stores qmlimportscanner in the libexecs folder, linuxdeploy-plugin-qt uses which to determine the location so if the libexecs folder isn't added to PATH it may select qmlimportscanner from another Qt version or not find it at all.