### PR TITLE
Don't try to deploy TLS plugins for Qt 6.0 or 6.1

### DIFF
--- a/src/deployers/PluginsDeployerFactory.cpp
+++ b/src/deployers/PluginsDeployerFactory.cpp
@@ -26,13 +26,15 @@ PluginsDeployerFactory::PluginsDeployerFactory(AppDir& appDir,
                                                bf::path qtInstallQmlPath,
                                                bf::path qtTranslationsPath,
                                                bf::path qtDataPath,
-                                               int qtMajorVersion) : appDir(appDir),
+                                               int qtMajorVersion,
+                                               int qtMinorVersion) : appDir(appDir),
                                                                       qtPluginsPath(std::move(qtPluginsPath)),
                                                                       qtLibexecsPath(std::move(qtLibexecsPath)),
                                                                       qtInstallQmlPath(std::move(qtInstallQmlPath)),
                                                                       qtTranslationsPath(std::move(qtTranslationsPath)),
                                                                       qtDataPath(std::move(qtDataPath)),
-                                                                      qtMajorVersion(qtMajorVersion) {}
+                                                                      qtMajorVersion(qtMajorVersion),
+                                                                      qtMinorVersion(qtMinorVersion) {}
 
 std::vector<std::shared_ptr<PluginsDeployer>> PluginsDeployerFactory::getDeployers(const std::string& moduleName) {
     if (moduleName == "gui") {
@@ -46,7 +48,7 @@ std::vector<std::shared_ptr<PluginsDeployer>> PluginsDeployerFactory::getDeploye
     if (moduleName == "network") {
         if (qtMajorVersion < 6) {
             return {getInstance<BearerPluginsDeployer>(moduleName)};
-        } else {
+        } else if (qtMinorVersion >= 2) {
             return {getInstance<TlsBackendsDeployer>(moduleName)};
         }
     }

--- a/src/deployers/PluginsDeployerFactory.h
+++ b/src/deployers/PluginsDeployerFactory.h
@@ -24,6 +24,7 @@ namespace linuxdeploy {
                 const boost::filesystem::path qtTranslationsPath;
                 const boost::filesystem::path qtDataPath;
                 const int qtMajorVersion;
+                const int qtMinorVersion;
 
                 template<typename T>
                 std::shared_ptr<PluginsDeployer> getInstance(const std::string& moduleName) {
@@ -47,7 +48,8 @@ namespace linuxdeploy {
                                                 boost::filesystem::path qtInstallQmlPath,
                                                 boost::filesystem::path qtTranslationsPath,
                                                 boost::filesystem::path qtDataPath,
-                                                int qtMajorVersion);
+                                                int qtMajorVersion,
+                                                int qtMinorVersion);
 
                 std::vector<std::shared_ptr<PluginsDeployer>> getDeployers(const std::string& moduleName);
             };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,12 +100,13 @@ int main(const int argc, const char *const *const argv) {
     const bf::path qtInstallQmlPath = qmakeVars["QT_INSTALL_QML"];
     const std::string qtVersion = qmakeVars["QT_VERSION"];
 
-    if (qtVersion.empty()) {
+    if (qtVersion.length() < 2) {
         ldLog() << LD_ERROR << "Failed to query QT_VERSION using qmake -query" << std::endl;
         return 1;
     }
 
     int qtMajorVersion = std::stoi(qtVersion, nullptr, 10);
+    int qtMinorVersion = std::stoi(qtVersion.substr(2), nullptr, 10);
     if (qtMajorVersion < 5) {
         ldLog() << std::endl << LD_WARNING << "Minimum Qt version supported is 5" << std::endl;
         qtMajorVersion = 5;
@@ -244,7 +245,8 @@ int main(const int argc, const char *const *const argv) {
         qtInstallQmlPath,
         qtTranslationsPath,
         qtDataPath,
-        qtMajorVersion
+        qtMajorVersion,
+        qtMinorVersion
     );
 
     for (const auto& module : qtModulesToDeploy) {


### PR DESCRIPTION
They were added in Qt 6.2.

Closes #95.
