### PR TITLE
Adjusted logic to find qmlimportscanner for Qt 6.2

### DIFF
--- a/src/deployers/QmlPluginsDeployer.cpp
+++ b/src/deployers/QmlPluginsDeployer.cpp
@@ -14,7 +14,7 @@ bool QmlPluginsDeployer::deploy() {
         return false;
 
     try {
-        deployQml(appDir, qtInstallQmlPath);
+        deployQml(appDir, qtInstallQmlPath, qtLibexecsPath);
     } catch (const QmlImportScannerError &) {
         return false;
     }

--- a/src/qml.h
+++ b/src/qml.h
@@ -18,13 +18,19 @@ struct QmlImportScannerError : public std::runtime_error {
 };
 
 // deploys QML files into AppDir
-void deployQml(linuxdeploy::core::appdir::AppDir &appDir, const boost::filesystem::path &installQmlPath);
+void deployQml(linuxdeploy::core::appdir::AppDir &appDir,
+               const boost::filesystem::path &installQmlPath,
+               const boost::filesystem::path &qtLibexecsPath);
 
-boost::filesystem::path findQmlImportScanner();
+boost::filesystem::path findQmlImportScanner(const boost::filesystem::path &qtLibexecsPath);
 
-std::string runQmlImportScanner(const std::vector<boost::filesystem::path> &sourcesPaths, const std::vector<boost::filesystem::path>& qmlImportPaths);
+std::string runQmlImportScanner(const boost::filesystem::path &qtLibexecsPath,
+                                const std::vector<boost::filesystem::path> &sourcesPaths,
+                                const std::vector<boost::filesystem::path>& qmlImportPaths);
 
 boost::filesystem::path getQmlModuleRelativePath(const std::vector<boost::filesystem::path>& qmlModulesImportPaths,
                                                  const boost::filesystem::path& qmlModulePath);
 
-std::vector<QmlModuleImport> getQmlImports(const boost::filesystem::path& projectRootPath, const boost::filesystem::path& installQmlPath);
+std::vector<QmlModuleImport> getQmlImports(const boost::filesystem::path& projectRootPath,
+                                           const boost::filesystem::path& installQmlPath,
+                                           const boost::filesystem::path &qtLibexecsPath);


### PR DESCRIPTION
In Qt 6.2, the qmlimportscanner moved to the libexec directory, so by default it can no longer be found in the PATH.

Adjusted findQmlImportScanner to look in the libexec directory first, and fall back to locating it in the PATH when it can't be found there.

Also raised a more specific error when the qmlimportscanner still can't be found, which is hopefully more helpful than the output you currently get when trying to deploy against Qt 6.2:
```
[qt/stdout] Calling:   -rootPath  AppDir  -importPath  /opt/Qt/6.2.2/gcc_64/qml
[qt/stdout] ERROR: terminate called after throwing an instance of 'std::runtime_error'
[qt/stdout]   what():  exec() failed: No such file or directory
```

Closes #93