### PR TITLE
Re-introduce all qt6modules

### DIFF
--- a/src/qt-modules.h
+++ b/src/qt-modules.h
@@ -127,7 +127,7 @@ static const std::vector<QtModule> Qt6Modules = {
     {"xcbqpa", "libQt6XcbQpa", ""},
     {"xml", "libQt6Xml", "qtbase"},
 
-    /* Not Included in Qt6.0.0, maybe some of them will be added back in 6.1, 6.2
+    /* Re-introduce for testing in 6.2+ */
 
     {"3danimation", "libQt63DAnimation", ""},
     {"3dcore", "libQt63DCore", ""},
@@ -143,7 +143,7 @@ static const std::vector<QtModule> Qt6Modules = {
     {"3dquick", "libQt63DQuick", ""},
     {"bluetooth", "libQt6Bluetooth", ""},
     {"clucene", "libQt6CLucene", "qt_help"},
-    {"declarative", "libQt6Declarative", "qtquick1"},
+    {"declarative", "libQt6Declarative", "qtquick2"},
     {"gamepad", "libQt6Gamepad", ""},
     {"location", "libQt6Location", ""},
     {"multimediagsttools", "libQt6MultimediaGstTools", "qtmultimedia"},
@@ -164,7 +164,6 @@ static const std::vector<QtModule> Qt6Modules = {
     {"websockets", "libQt6WebSockets", "qtwebsockets"},
     {"x11extras", "libQt6X11Extras", ""},
     {"xmlpatterns", "libQt6XmlPatterns", "qtxmlpatterns"},
-    */
    
 };
 


### PR DESCRIPTION
This PR follows on from https://github.com/linuxdeploy/linuxdeploy-plugin-qt/pull/113 by re-introducing all qt6modules that were previously left out during the 6.0-6.1 phase.

All Qt6 modules are (in theory) now available in >=6.2
https://www.qt.io/blog/qt-6.2-lts-released

Note: keeping the re-introduced modules in a separate block for now until we can confirm there are no wrinkles.

Also: As a guess, I changed `qtquick1` to `qtquick2` for the `declarative` module. I'm not sure about this yet though.