### PR TITLE
Support deploying Qt 6 multimedia plugins.

### DIFF
--- a/src/deployers/CMakeLists.txt
+++ b/src/deployers/CMakeLists.txt
@@ -12,7 +12,8 @@ set(CLASSES
     SqlPluginsDeployer
     PositioningPluginsDeployer
     LocationPluginsDeployer
-    MultimediaPluginsDeployer
+    Multimedia5PluginsDeployer
+    Multimedia6PluginsDeployer
     WebEnginePluginsDeployer
     QmlPluginsDeployer
     Qt3DPluginsDeployer

--- a/src/deployers/Multimedia5PluginsDeployer.cpp
+++ b/src/deployers/Multimedia5PluginsDeployer.cpp
@@ -5,14 +5,14 @@
 #include <linuxdeploy/core/log.h>
 
 // local headers
-#include "MultimediaPluginsDeployer.h"
+#include "Multimedia5PluginsDeployer.h"
 
 using namespace linuxdeploy::plugin::qt;
 using namespace linuxdeploy::core::log;
 
 namespace fs = std::filesystem;
 
-bool MultimediaPluginsDeployer::deploy() {
+bool Multimedia5PluginsDeployer::deploy() {
     // calling the default code is optional, but it won't hurt for now
     if (!BasicPluginsDeployer::deploy())
         return false;

--- a/src/deployers/Multimedia5PluginsDeployer.h
+++ b/src/deployers/Multimedia5PluginsDeployer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "BasicPluginsDeployer.h"
+
+namespace linuxdeploy {
+    namespace plugin {
+        namespace qt {
+            class Multimedia5PluginsDeployer : public BasicPluginsDeployer {
+            public:
+                // we can just use the base class's constructor
+                using BasicPluginsDeployer::BasicPluginsDeployer;
+
+                bool deploy() override;
+            };
+        }
+    }
+}

--- a/src/deployers/Multimedia6PluginsDeployer.cpp
+++ b/src/deployers/Multimedia6PluginsDeployer.cpp
@@ -1,0 +1,32 @@
+// system headers
+#include <filesystem>
+
+// library headers
+#include <linuxdeploy/core/log.h>
+
+// local headers
+#include "Multimedia6PluginsDeployer.h"
+
+using namespace linuxdeploy::plugin::qt;
+using namespace linuxdeploy::core::log;
+
+namespace fs = std::filesystem;
+
+bool Multimedia6PluginsDeployer::deploy() {
+    // calling the default code is optional, but it won't hurt for now
+    if (!BasicPluginsDeployer::deploy())
+        return false;
+
+    if (fs::exists(qtPluginsPath / "multimedia")) {
+        ldLog() << "Deploying multimedia plugins" << std::endl;
+
+        for (fs::directory_iterator i(qtPluginsPath / "multimedia"); i != fs::directory_iterator(); ++i) {
+            if (!appDir.deployLibrary(*i, appDir.path() / "usr/plugins/multimedia/"))
+                return false;
+        }
+    } else {
+        ldLog() << LD_WARNING << "Missing Qt 6 multimedia plugins, skipping." << std::endl;
+    }
+
+    return true;
+}

--- a/src/deployers/Multimedia6PluginsDeployer.h
+++ b/src/deployers/Multimedia6PluginsDeployer.h
@@ -5,7 +5,7 @@
 namespace linuxdeploy {
     namespace plugin {
         namespace qt {
-            class MultimediaPluginsDeployer : public BasicPluginsDeployer {
+            class Multimedia6PluginsDeployer : public BasicPluginsDeployer {
             public:
                 // we can just use the base class's constructor
                 using BasicPluginsDeployer::BasicPluginsDeployer;

--- a/src/deployers/PluginsDeployerFactory.cpp
+++ b/src/deployers/PluginsDeployerFactory.cpp
@@ -5,7 +5,8 @@
 #include "BearerPluginsDeployer.h"
 #include "GamepadPluginsDeployer.h"
 #include "LocationPluginsDeployer.h"
-#include "MultimediaPluginsDeployer.h"
+#include "Multimedia5PluginsDeployer.h"
+#include "Multimedia6PluginsDeployer.h"
 #include "PrintSupportPluginsDeployer.h"
 #include "PositioningPluginsDeployer.h"
 #include "QmlPluginsDeployer.h"
@@ -70,8 +71,12 @@ std::vector<std::shared_ptr<PluginsDeployer>> PluginsDeployerFactory::getDeploye
         return {getInstance<PositioningPluginsDeployer>(moduleName)};
     }
 
-    if (qtMajorVersion < 6 && moduleName == "multimedia") {
-        return {getInstance<MultimediaPluginsDeployer>(moduleName)};
+    if (moduleName == "multimedia") {
+	if (qtMajorVersion < 6) {
+            return {getInstance<Multimedia5PluginsDeployer>(moduleName)};
+	} else {
+            return {getInstance<Multimedia6PluginsDeployer>(moduleName)};
+        }
     }
 
     if (moduleName == "webenginecore") {


### PR DESCRIPTION
Adds support for deploying Qt 6 multimedia plugins. All of the multimedia plugin directories are now gated behind fs::exists checks to support both Qt 5 and Qt 6 configurations.

Fixes https://github.com/linuxdeploy/linuxdeploy-plugin-qt/issues/144