### PR TITLE
Adding missing include for CMake FetchContent_Declare command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(nlohmann_json)
 if(NOT nlohmann_json_FOUND)
     message(STATUS "nlohmann_json not found on system, fetching from GitHub")
 
+    include(FetchContent)
     FetchContent_Declare(
         nlohmann_json
         GIT_REPOSITORY https://github.com/nlohmann/json


### PR DESCRIPTION
In main `CMakeLists.txt` file if `nlohmann_json` library is not found in system then is fetched from github repository by using `FetchContent_Declare` command which should be included from [FetchContent_Declare](https://cmake.org/cmake/help/latest/module/FetchContent.html) module. Without that include there is CMake error:
```
CMake Error at CMakeLists.txt:22 (FetchContent_Declare):
  Unknown CMake command "FetchContent_Declare".
```