### PR TITLE
Adding option to install linuxdeploy application with linuxdeploy qt plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.6)
 project(linuxdeploy-plugin-qt)
 
+option(INSTALL_LINUX_DEPLOY_APP "Decides if linuxdeploy application is installed with linuxdeployqt plugin" OFF)
+
 include(CTest)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,1 +1,5 @@
-add_subdirectory(linuxdeploy EXCLUDE_FROM_ALL)
+if ($CACHE{INSTALL_LINUX_DEPLOY_APP})
+    add_subdirectory(linuxdeploy)
+else ()
+    add_subdirectory(linuxdeploy EXCLUDE_FROM_ALL)
+endif ()


### PR DESCRIPTION
# Why?

Now when user would like to have linuxdeploy application and linuxdeployqt plugin needs to download, build two repositories. Adding CMake flag `INSTALL_LINUX_DEPLOY_APP` (by default `OFF` to keep current behaviour) let user decide if linuxdeploy application is installed with linuxdeployqt plugin to CMAKE_INSTALL_PREFIX directory.

# How?
Just download linuxdeploy repository, build and install.