### PR TITLE
multiple deployers: Ignore .debug files

### DIFF
--- a/src/deployers/BasicPluginsDeployer.cpp
+++ b/src/deployers/BasicPluginsDeployer.cpp
@@ -39,6 +39,10 @@ bool BasicPluginsDeployer::deployStandardQtPlugins(const std::vector<std::string
     for (const auto &pluginName : plugins) {
         ldLog() << "Deploying Qt" << pluginName << "plugins" << std::endl;
         for (fs::directory_iterator i(qtPluginsPath / pluginName); i != fs::directory_iterator(); ++i) {
+            if (i->path().extension() == ".debug") {
+                ldLog() << LD_DEBUG << "skipping .debug file:" << i->path() << std::endl;
+                continue;
+            }
             // add a trailing slash, so pluginName is used as a destination directory, not a file.
             if (!appDir.deployLibrary(*i, appDir.path() / "usr/plugins" / pluginName / ""))
                 return false;

--- a/src/deployers/TextToSpeechPluginsDeployer.cpp
+++ b/src/deployers/TextToSpeechPluginsDeployer.cpp
@@ -1,38 +1,8 @@
-// system headers
-#include <filesystem>
-
-// library headers
-#include <linuxdeploy/core/log.h>
-
 // local headers
 #include "TextToSpeechPluginsDeployer.h"
 
 using namespace linuxdeploy::plugin::qt;
-using namespace linuxdeploy::core::log;
-
-namespace fs = std::filesystem;
 
 bool TextToSpeechPluginsDeployer::doDeploy() {
-    // calling the default code is optional, but it won't hurt for now
-    if (!BasicPluginsDeployer::deploy())
-        return false;
-
-    const std::string pluginsName = "texttospeech";
-
-    ldLog() << "Deploying" << pluginsName << "plugins" << std::endl;
-
-    for (fs::directory_iterator i(qtPluginsPath / pluginsName); i != fs::directory_iterator(); ++i) {
-        if (i->path().extension() == ".debug") {
-            ldLog() << LD_DEBUG << "skipping .debug file:" << i->path() << std::endl;
-            continue;
-        }
-
-        // terminate with a "/" to make sure the deployer will deploy the file into the target directory properly
-        // has to be cast to string, unfortunately, as std::filesystem doesn't allow for adding a terminating /
-        const auto targetPath = (appDir.path() / "usr/plugins/" / pluginsName).string() + "/";
-        if (!appDir.deployLibrary(*i, targetPath))
-            return false;
-    }
-
-    return true;
+    return deployStandardQtPlugins({"texttospeech"});
 }

--- a/src/deployment.h
+++ b/src/deployment.h
@@ -37,6 +37,10 @@ inline bool deployIntegrationPlugins(appdir::AppDir& appDir, const fs::path& qtP
             // otherwise, when the directory doesn't exist, it might just copy all files to files called like
             // destinationDir
             auto destinationDir = appDir.path() / "usr/plugins" / subDir / "";
+            if (i->path().extension() == ".debug") {
+                ldLog() << LD_DEBUG << "skipping .debug file:" << i->path() << std::endl;
+                continue;
+            }
 
             if (!appDir.deployLibrary(*i, destinationDir))
                 return false;


### PR DESCRIPTION
This commit replicates a pattern from the TextToSpeechPluginsDeployer across a range of other deployer classes.

Essentially - it's extremely unlikely that composing an AppImage with debug symbols is what a user actually wants to do. I'm also not aware of a good story for connecting debug symbols to an AppImage at all.

As a result, let's make a sensible choice - and not package them. Trust that developers will use their underlying build system for Debug, and that release tracking will allow developers to tie an AppImage back to a source control revision.

Finally, note that this works around an interesting aarch64 bug - where the .debug files that are created are marked as x86_64 ELF binaries - even when you are _building on an aarch64 host_.

Fixes: #110, but not in the manner suggested by the first respondent as they have conflated a desire to remove the .debug objects with a desire to remove text objects.