### PR TITLE
Wayland client support

### DIFF
--- a/src/deployers/CMakeLists.txt
+++ b/src/deployers/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CLASSES
     TextToSpeechPluginsDeployer
     TlsBackendsDeployer
     WaylandcompositorPluginsDeployer
+    WaylandShellIntegrationPluginsDeployer
 )
 
 # TODO: CMake <= 3.7 (at least!) doesn't allow for using OBJECT libraries with target_link_libraries

--- a/src/deployers/CMakeLists.txt
+++ b/src/deployers/CMakeLists.txt
@@ -23,6 +23,7 @@ set(CLASSES
     TlsBackendsDeployer
     WaylandcompositorPluginsDeployer
     WaylandShellIntegrationPluginsDeployer
+    WaylandGraphicsIntegrationClientPluginsDeployer
 )
 
 # TODO: CMake <= 3.7 (at least!) doesn't allow for using OBJECT libraries with target_link_libraries

--- a/src/deployers/PluginsDeployerFactory.cpp
+++ b/src/deployers/PluginsDeployerFactory.cpp
@@ -19,6 +19,7 @@
 #include "TlsBackendsDeployer.h"
 #include "WaylandcompositorPluginsDeployer.h"
 #include "WaylandShellIntegrationPluginsDeployer.h"
+#include "WaylandGraphicsIntegrationClientPluginsDeployer.h"
 
 using namespace linuxdeploy::plugin::qt;
 using namespace linuxdeploy::core::appdir;
@@ -111,6 +112,10 @@ std::vector<std::shared_ptr<PluginsDeployer>> PluginsDeployerFactory::getDeploye
 
     if (moduleName == "wayland-shell-integration") {
         return {getInstance<WaylandShellIntegrationPluginsDeployer>(moduleName)};
+    }
+
+    if (moduleName == "wayland-graphics-integration-client") {
+        return {getInstance<WaylandGraphicsIntegrationClientPluginsDeployer>(moduleName)};
     }
 
     // fallback

--- a/src/deployers/PluginsDeployerFactory.cpp
+++ b/src/deployers/PluginsDeployerFactory.cpp
@@ -18,6 +18,7 @@
 #include "XcbglIntegrationPluginsDeployer.h"
 #include "TlsBackendsDeployer.h"
 #include "WaylandcompositorPluginsDeployer.h"
+#include "WaylandShellIntegrationPluginsDeployer.h"
 
 using namespace linuxdeploy::plugin::qt;
 using namespace linuxdeploy::core::appdir;
@@ -106,6 +107,10 @@ std::vector<std::shared_ptr<PluginsDeployer>> PluginsDeployerFactory::getDeploye
 
     if (moduleName == "waylandcompositor") {
         return {getInstance<WaylandcompositorPluginsDeployer>(moduleName)};
+    }
+
+    if (moduleName == "wayland-shell-integration") {
+        return {getInstance<WaylandShellIntegrationPluginsDeployer>(moduleName)};
     }
 
     // fallback

--- a/src/deployers/WaylandGraphicsIntegrationClientPluginsDeployer.cpp
+++ b/src/deployers/WaylandGraphicsIntegrationClientPluginsDeployer.cpp
@@ -1,0 +1,34 @@
+// system headers
+#include <filesystem>
+
+// library headers
+#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/util/util.h>
+
+// local headers
+#include "WaylandGraphicsIntegrationClientPluginsDeployer.h"
+
+using namespace linuxdeploy::plugin::qt;
+using namespace linuxdeploy::core::log;
+
+namespace fs = std::filesystem;
+
+bool WaylandGraphicsIntegrationClientPluginsDeployer::deploy() {
+    // calling the default code is optional, but it won't hurt for now
+    if (!BasicPluginsDeployer::deploy())
+        return false;
+
+    ldLog() << "Deploying Wayland Shell Integration plugins" << std::endl;
+
+    for (fs::directory_iterator i(qtPluginsPath / "wayland-graphics-integration-client"); i != fs::directory_iterator(); ++i) {
+        if (i->path().extension() == ".debug") {
+            ldLog() << LD_DEBUG << "skipping .debug file:" << i->path() << std::endl;
+            continue;
+        }
+
+        if (!appDir.deployLibrary(*i, appDir.path() / "usr/plugins/wayland-graphics-integration-client/"))
+            return false;
+    }
+
+    return true;
+}

--- a/src/deployers/WaylandGraphicsIntegrationClientPluginsDeployer.h
+++ b/src/deployers/WaylandGraphicsIntegrationClientPluginsDeployer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "BasicPluginsDeployer.h"
+
+namespace linuxdeploy {
+    namespace plugin {
+        namespace qt {
+            class WaylandGraphicsIntegrationClientPluginsDeployer : public BasicPluginsDeployer {
+            public:
+                // we can just use the base class's constructor
+                using BasicPluginsDeployer::BasicPluginsDeployer;
+
+                bool deploy() override;
+            };
+        }
+    }
+}

--- a/src/deployers/WaylandShellIntegrationPluginsDeployer.cpp
+++ b/src/deployers/WaylandShellIntegrationPluginsDeployer.cpp
@@ -1,0 +1,38 @@
+// system headers
+#include <filesystem>
+
+// library headers
+#include <linuxdeploy/core/log.h>
+#include <linuxdeploy/util/util.h>
+
+// local headers
+#include "WaylandShellIntegrationPluginsDeployer.h"
+
+using namespace linuxdeploy::plugin::qt;
+using namespace linuxdeploy::core::log;
+
+namespace fs = std::filesystem;
+
+bool WaylandShellIntegrationPluginsDeployer::deploy() {
+    // calling the default code is optional, but it won't hurt for now
+    if (!BasicPluginsDeployer::deploy())
+        return false;
+
+    ldLog() << "Deploying Wayland Shell Integration plugins" << std::endl;
+
+    // always deploy default platform
+    if (!appDir.deployLibrary(qtPluginsPath / "wayland-shell-integration/libxdg-shell.so", appDir.path() / "usr/plugins/wayland-shell-integration/"))
+        return false;
+
+    // deploy Wayland Shell Integration platform plugins, if any
+    const auto* const platformPluginsFromEnvData = getenv("EXTRA_WAYLAND_SHELL_INTEGRATION_PLUGINS");
+    if (platformPluginsFromEnvData != nullptr) {
+        for (const auto& platformToDeploy : linuxdeploy::util::split(std::string(platformPluginsFromEnvData), ';')) {
+            ldLog() << "Deploying extra Wayland Shell Integration plugin: " << platformToDeploy << std::endl;
+            if (!appDir.deployLibrary(qtPluginsPath / "wayland-shell-integration" / platformToDeploy, appDir.path() / "usr/plugins/wayland-shell-integration/"))
+                return false;
+        }
+     }
+
+    return true;
+}

--- a/src/deployers/WaylandShellIntegrationPluginsDeployer.h
+++ b/src/deployers/WaylandShellIntegrationPluginsDeployer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "BasicPluginsDeployer.h"
+
+namespace linuxdeploy {
+    namespace plugin {
+        namespace qt {
+            class WaylandShellIntegrationPluginsDeployer : public BasicPluginsDeployer {
+            public:
+                // we can just use the base class's constructor
+                using BasicPluginsDeployer::BasicPluginsDeployer;
+
+                bool deploy() override;
+            };
+        }
+    }
+}

--- a/src/qt-modules.h
+++ b/src/qt-modules.h
@@ -122,6 +122,7 @@ static const std::vector<QtModule> Qt6Modules = {
     {"uitools", "libQt6UiTools", ""},
     {"waylandclient", "libQt6WaylandClient", ""},
     {"wayland-shell-integration", "libQt6WlShellIntegration", ""},
+    {"wayland-graphics-integration-client", "", ""},
     {"waylandcompositor", "libQt6WaylandCompositor", ""},
     {"webenginecore", "libQt6WebEngineCore", ""},
     {"webengine", "libQt6WebEngine", "qtwebengine"},

--- a/src/qt-modules.h
+++ b/src/qt-modules.h
@@ -121,6 +121,7 @@ static const std::vector<QtModule> Qt6Modules = {
     {"test", "libQt6Test", "qtbase"},
     {"uitools", "libQt6UiTools", ""},
     {"waylandclient", "libQt6WaylandClient", ""},
+    {"wayland-shell-integration", "libQt6WlShellIntegration", ""},
     {"waylandcompositor", "libQt6WaylandCompositor", ""},
     {"webenginecore", "libQt6WebEngineCore", ""},
     {"webengine", "libQt6WebEngine", "qtwebengine"},


### PR DESCRIPTION
With these commits, and a suitable AppImageCraft configuration, I can package Raspberry Pi Imager with the Wayland QPA platform and avoid the use of Xserver on Raspberry Pi OS Bookworm (and likely _other_ clients too).

Fixes: #160 and #130.