### PR TITLE
Small QML_SOURCES_PATHS README addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ Just like all linuxdeploy plugins, the Qt plugin's behavior can be configured so
 - `$EXTRA_PLATFORM_PLUGINS=platformA;platformB`: Platforms to deploy in addition to `libqxcb.so`. Platform must be available from `QT_INSTALL_PLUGINS/platforms`.
 
 QML related:
-- `$QML_SOURCES_PATHS`: directory containing the application's QML files — useful/needed if QML files are "baked" into the binaries. `$QT_INSTALL_QML` is prepended to this list internally.
+- `$QML_SOURCES_PATHS`: directory containing the application's QML files — useful/needed if QML files are "baked" into the binaries. linuxdeploy-plugin-qt will look for all imported QML modules and include them. `$QT_INSTALL_QML` is prepended to this list internally.
 - `$QML_MODULES_PATHS`: extra directories containing imported QML files (normally doesn't need to be specified).


### PR DESCRIPTION
Mention that files in QML_SOURCES_PATHS are checked for imported modules, and that those modules will be included in AppDir.

It wasn't obvious to me how QML modules get included. Hopefully this helps the next guy.