### PR TITLE
Deploy Wayland Shell integration and decoration

### DIFF
--- a/src/deployers/PlatformPluginsDeployer.cpp
+++ b/src/deployers/PlatformPluginsDeployer.cpp
@@ -27,6 +27,13 @@ bool PlatformPluginsDeployer::doDeploy() {
             ldLog() << "Deploying extra platform plugin: " << platformToDeploy << std::endl;
             if (!appDir.deployLibrary(qtPluginsPath / "platforms" / platformToDeploy, appDir.path() / "usr/plugins/platforms/"))
                 return false;
+
+            using namespace linuxdeploy::util::misc;
+            if (stringStartsWith(platformToDeploy, "libqwayland")) {
+                if (!deployStandardQtPlugins({"wayland-decoration-client", "wayland-shell-integration"})) {
+                    return false;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
When EXTRA_PLATFORM_PLUGINS has libqwayland-* we
should also deploy the shell and decoration
plugins.